### PR TITLE
Adding platform team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @catawiki/platform-team


### PR DESCRIPTION
Note: It looks like the original repo is now archived too....