### PR TITLE
[PT-5680] Add build step to compile gcs-helper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+FROM gcr.io/cloud-builders/go:alpine as build
+
+COPY . ./
+RUN go mod download \
+    && env CGO_ENABLED=0 GO111MODULE=on GOPROXY=https://proxy.golang.org go build -o gcs-helper
+
 FROM alpine:3.9
 RUN  apk add --no-cache ca-certificates
-ADD  gcs-helper /usr/bin/gcs-helper
+COPY --from=build /go/gcs-helper /usr/bin/gcs-helper
 ENTRYPOINT ["/usr/bin/gcs-helper"]


### PR DESCRIPTION
Based on https://github.com/catawiki/gcs-helper/blob/cloudbuild/Dockerfile , but skipping some unnecessary steps.
The cloudbuild branch get be deleted after this PR. Also I'll create a follow up PR to upgrade Alpine.

The image can be build with:
```
docker build --platform linux/amd64 -t europe-docker.pkg.dev/cw-dev-platform-host-0001/gcs-helper/gcs-helper:$(git rev-parse --short=7 HEAD) .
```